### PR TITLE
Fix kubernetes-py import

### DIFF
--- a/powerkube/__init__.py
+++ b/powerkube/__init__.py
@@ -1,4 +1,4 @@
-import kubernetes
+import kubernetes_py as kubernetes
 from powerline.theme import requires_segment_info
 
 _KUBE_SYMBOL = u'\U00002388 '

--- a/tests/test_powerkube.py
+++ b/tests/test_powerkube.py
@@ -1,6 +1,6 @@
 import logging
 
-import kubernetes
+import kubernetes_py as kubernetes
 import pytest
 
 import powerkube as pk


### PR DESCRIPTION
As the project is using the `kubernetes-py` library -> https://github.com/zcmarine/powerkube/blob/master/setup.py#L3-L6, the import name is `kubernetes_py` instead of `kubernetes`.

Fixes https://github.com/zcmarine/powerkube/issues/2